### PR TITLE
[BUG]: Clear out inputs in the add item form after clicking OK on the alert

### DIFF
--- a/src/components/AddItem.jsx
+++ b/src/components/AddItem.jsx
@@ -2,10 +2,12 @@ import { useState } from 'react';
 import { addItem } from '../api/firebase';
 
 export default function AddItem({ listPath }) {
-	const [itemValue, setItemValue] = useState({
+	const initialState = {
 		itemName: '',
 		daysUntilNextPurchase: 0,
-	});
+	};
+
+	const [itemValue, setItemValue] = useState(initialState);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -13,6 +15,7 @@ export default function AddItem({ listPath }) {
 		try {
 			await addItem(listPath, itemValue);
 			alert('Item added!');
+			setItemValue(initialState);
 		} catch (err) {
 			alert('Error adding item to database');
 		}


### PR DESCRIPTION
## Description

This change will reset the input on the `ManageList` view back to its initial state when a user adds a new item to their list. I added an `initalState` variable that can be used when first setting the input state and upon form submit to reset back to said initial state.

## Related Issue

closes #29 

## Type of Changes

Bug fix

## Updates

### Before

https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/103898493/9bbac0bf-d8cd-41fd-8bf9-8adcda313f6a

### After

https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/103898493/211e0f80-8a0b-40f3-be91-641ae887cefe

## Testing Steps / QA Criteria

1. git pull
2. git checkout bugfix-clear-input
3. npm start
4. click on the list you'd like to add an item to
5. navigate to manage-list
6. add a new item to your list 
