### PR TITLE
11. As an item, I want my estimated next purchase date to be computed at the time my purchase is recorded in the database, so the app can learn how often I buy different items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.2.0",
 				"firebase": "^10.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3992,6 +3993,15 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.2.0.tgz",
+			"integrity": "sha512-nEN1z/SEOIWO+8JWIgPDNUkrXmXqNomSh5aiZDNdiaUH/JYqyNeXmEOldtMqAfLicSRiFkapcAIlrUUnPzNaog==",
+			"peerDependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.2.0",
 		"firebase": "^10.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -189,6 +189,10 @@ export async function updateItem(listPath, itemId, dateLastPurchased) {
 	const listCollectionRef = collection(db, listPath, 'items');
 
 	const itemDocRef = doc(listCollectionRef, itemId);
+
+	// const docSnap = await getDoc(itemDocRef);
+	// const item = docSnap.data();
+
 	return updateDoc(itemDocRef, {
 		dateLastPurchased,
 		totalPurchases: increment(1),

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -185,16 +185,19 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(listPath, itemId, dateLastPurchased) {
+export async function updateItem(
+	listPath,
+	itemId,
+	dateLastPurchased,
+	nextPurchaseEstimate,
+) {
 	const listCollectionRef = collection(db, listPath, 'items');
 
 	const itemDocRef = doc(listCollectionRef, itemId);
 
-	// const docSnap = await getDoc(itemDocRef);
-	// const item = docSnap.data();
-
 	return updateDoc(itemDocRef, {
 		dateLastPurchased,
+		dateNextPurchased: getFutureDate(nextPurchaseEstimate),
 		totalPurchases: increment(1),
 	});
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,5 @@
 import { updateItem } from '../api';
-import { subtractDates, getFutureDate } from '../utils';
+import { subtractDates } from '../utils';
 import { Timestamp } from 'firebase/firestore';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import './ListItem.css';
@@ -34,8 +34,6 @@ export function ListItem({
 		daysSinceLastTransaction,
 		totalPurchases,
 	);
-
-	// const dateOfNextPurchase = Timestamp.fromDate(getFutureDate(nextPurchase));
 
 	const handleChecked = async () => {
 		try {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,5 @@
 import { updateItem } from '../api';
-import { subtractDates } from '../utils';
+import { subtractDates, getFutureDate } from '../utils';
 import { Timestamp } from 'firebase/firestore';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import './ListItem.css';
@@ -16,33 +16,30 @@ export function ListItem({
 	const todaysDate = Timestamp.now();
 
 	// if dateLastPurchased is true subtract it from dateNextPurchased, else subtract dateCreated from dateNextPurchased to get the estimated number of days till next purchase
-	// const previousEstimate = Math.ceil(
-	// 	(dateNextPurchased.toMillis() -
-	// 		(dateLastPurchased
-	// 			? dateLastPurchased.toMillis()
-	// 			: dateCreated.toMillis())) /
-	// 		(1000 * 60 * 60 * 24),
-	// );
+	const previousEstimate = Math.ceil(
+		(dateNextPurchased.toDate() -
+			(dateLastPurchased ? dateLastPurchased.toDate() : dateCreated.toDate())) /
+			(24 * 60 * 60 * 1000),
+	);
 
 	// if dateLastPurchased is true subtract it from todaysDate, else subtract dateCreated from todaysDate to get the number of days since the last transaction
 	const daysSinceLastTransaction = Math.floor(
-		(todaysDate.toMillis() -
-			(dateLastPurchased
-				? dateLastPurchased.toMillis()
-				: dateCreated.toMillis())) /
-			(1000 * 60 * 60 * 24),
+		(todaysDate.toDate() -
+			(dateLastPurchased ? dateLastPurchased.toDate() : dateCreated.toDate())) /
+			(24 * 60 * 60 * 1000),
 	);
 
-	const nextPurchase = calculateEstimate(
-		14,
+	const nextPurchaseEstimate = calculateEstimate(
+		previousEstimate,
 		daysSinceLastTransaction,
 		totalPurchases,
 	);
-	console.log(nextPurchase);
+
+	// const dateOfNextPurchase = Timestamp.fromDate(getFutureDate(nextPurchase));
 
 	const handleChecked = async () => {
 		try {
-			await updateItem(listPath, id, todaysDate);
+			await updateItem(listPath, id, todaysDate, nextPurchaseEstimate);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,10 +1,44 @@
 import { updateItem } from '../api';
 import { subtractDates } from '../utils';
 import { Timestamp } from 'firebase/firestore';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import './ListItem.css';
 
-export function ListItem({ name, listPath, id, dateLastPurchased }) {
+export function ListItem({
+	name,
+	listPath,
+	id,
+	dateLastPurchased,
+	dateNextPurchased,
+	totalPurchases,
+	dateCreated,
+}) {
 	const todaysDate = Timestamp.now();
+
+	// if dateLastPurchased is true subtract it from dateNextPurchased, else subtract dateCreated from dateNextPurchased to get the estimated number of days till next purchase
+	// const previousEstimate = Math.ceil(
+	// 	(dateNextPurchased.toMillis() -
+	// 		(dateLastPurchased
+	// 			? dateLastPurchased.toMillis()
+	// 			: dateCreated.toMillis())) /
+	// 		(1000 * 60 * 60 * 24),
+	// );
+
+	// if dateLastPurchased is true subtract it from todaysDate, else subtract dateCreated from todaysDate to get the number of days since the last transaction
+	const daysSinceLastTransaction = Math.floor(
+		(todaysDate.toMillis() -
+			(dateLastPurchased
+				? dateLastPurchased.toMillis()
+				: dateCreated.toMillis())) /
+			(1000 * 60 * 60 * 24),
+	);
+
+	const nextPurchase = calculateEstimate(
+		14,
+		daysSinceLastTransaction,
+		totalPurchases,
+	);
+	console.log(nextPurchase);
 
 	const handleChecked = async () => {
 		try {

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -51,6 +51,9 @@ export function List({ data, listPath, loading }) {
 								name={item.name}
 								id={item.id}
 								dateLastPurchased={item.dateLastPurchased}
+								dateNextPurchased={item.dateNextPurchased}
+								totalPurchases={item.totalPurchases}
+								dateCreated={item.dateCreated}
 								listPath={listPath}
 							/>
 						))}


### PR DESCRIPTION
## Description

We imported the `@the-collab-lab/shopping-list-utils` module to utilize the calculateEstimate function.

In our `ListItem.jsx` we:
- Added a `previousEstimate` variable that checks if dateLastPurchased is true and subtracts it from dateNextPurchased, else it will subtract the dateCreated from dateNextPurchased to get the estimated number of days till next purchase
- Added a `daysSinceLastTransaction` variable that checks if dateLastPurchased is true and subtracts it from todaysDate, else it will subtract the dateCreated from todaysDate to get the number of days since the last transaction
- Implemented the `calculateEstimate` function from the `@the-collab-lab/shopping-list-utils` module, utilizing the previousEstimate and daysSinceLastPurchase we calculated, and the total number of purchases of the item
- Passed todaysDate (as a timestamp) and our nextPurchaseEstimate (calculated from the calculateEstimate functionality), when item is checked, into our firebase `updateItem` function

In `firebase.js` we:
- Utilized the `getFutureDate` function from our date utils and passed our nextPurchaseEstimate as the parameter to set our dateNextPurchased
- Incremented our totalPurchases by 1 to update the total in the database

We put the logic for calculating the dateLastPurchased and or nextPurchase on the frontend instead of in firebase to avoid passing logic back and forth and creating clutter in the code. We were unsure if that is the most efficient or "best" route, and are open to feedback for better alternatives.

While testing, we found it difficult to check the exact math for the calculateEstimate function, but everything seemed to be right. Basically, that function takes the amount of days between purchases, averages them, and returns a whole number for the average amount of days between purchases.

## Related Issue

closes #11 

## Acceptance Criteria

- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

***Some notes***
It felt like our acceptance criteria was based on previous logic for this project. `getDaysBetweenDates` is not a function in our utils, but `getFutureDate` was, so we wrote our logic/functionality utilizing that function instead. Because of this, we utilized the calculateEstimate function to give us the amount of days until our next purchase and the utilized the getFutureDate to convert the amount of days into our future date for purchase.


## Type of Changes

enhancement

## Updates

### Before

Not UI / Changes are in [database](https://console.firebase.google.com/u/3/project/tcl-66-smart-shopping-list/firestore/data/~2F)

### After

Not UI / Changes are in [database](https://console.firebase.google.com/u/3/project/tcl-66-smart-shopping-list/firestore/data/~2F)

## Testing Steps / QA Criteria

1. git pull from main
2. git checkout an-hm-issue-11
3. npm install
4. npm start
5. click a list to navigate to its list page 
   - note: it is easier to test on a list that you are the owner of, but will work on any list. Additionally, you will need at least one item in your list, so choosing a list with item(s) or adding new items to a list is necessary
6. check the box of an item and then navigate to the corresponding list in the [database](https://console.firebase.google.com/u/3/project/tcl-66-smart-shopping-list/firestore/data/~2F)
   - you will need to navigate to the correct collection to find the list and corresponding items; this is why it is easier if you add to your own list, that way you can click your uid in the collection list
   - the path of navigation should look like: uid --> list you are testing --> items --> id of item
7. read through fields of item
8. go back to the localhost app and check the box of the item you previously checked
9. navigate back to the database to check how the fields have changed
    - note: if the totalPurchases is 2 or less, the dateNextPurchased will either be the initial date set at time of item added (based on users dropdown input) or the current date because the calculateEstimate function is creating an average and does not recognize 2 purchases as being enough data. 
10. to test the averaging, you will need to manually change the dateLastPurchased to something before today's date, it will then update the dateNextPurchased
11. after manually changing the date you can navigate back to the localhost app and check the item again
12. navigate back to the database to see how it has affected the data (this can be repeated for testing)
