### PR TITLE
issue-20[BUG-FIX]

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 import { Home, Layout, List, ManageList, Err, Login } from './views';
 
-import { PublicRoute, PrivateRoute, Spinner } from './components';
+import { PublicRoute, PrivateRoute } from './components';
 
 import { useAuth } from './api';
 
@@ -41,9 +41,6 @@ export function App() {
 	 */
 	const { data, loading, setLoading } = useShoppingListData(listPath);
 
-	if (loading) {
-		return <Spinner />;
-	}
 	return (
 		<Router>
 			<Routes>

--- a/src/api/useAuth.jsx
+++ b/src/api/useAuth.jsx
@@ -8,6 +8,7 @@ import {
 import { addUserToDatabase } from './firebase.js';
 import { useNavigate } from 'react-router-dom';
 import GoogleIcon from '../assets/GoogleIcon.jsx';
+import { Spinner } from '../components/Spinner.jsx';
 
 /**
  * A button that signs the user in using Google OAuth. When clicked,
@@ -16,8 +17,10 @@ import GoogleIcon from '../assets/GoogleIcon.jsx';
  */
 
 export const SignInButton = () => {
+	const [loading, setLoading] = useState(false);
 	const handleSignIn = async () => {
 		try {
+			setLoading(true);
 			// Attempt sign-in with a popup
 			await signInWithPopup(auth, new GoogleAuthProvider());
 		} catch (error) {
@@ -34,6 +37,8 @@ export const SignInButton = () => {
 				console.error('Error during popup sign-in:', error);
 				// TODO ADD TOAST ONCE COMPONENT COMMITTED
 			}
+		} finally {
+			setLoading(false);
 		}
 	};
 
@@ -44,6 +49,7 @@ export const SignInButton = () => {
 			aria-label="Sign up or Log in with google verification"
 			onClick={handleSignIn}
 		>
+			{loading ? <Spinner /> : null}
 			<GoogleIcon /> Verify with Google
 		</button>
 	);
@@ -53,16 +59,20 @@ export const SignInButton = () => {
  * A button that signs the user out of the app using Firebase Auth.
  */
 export const SignOutButton = () => {
+	const [loading, setLoading] = useState(false);
 	const navigate = useNavigate();
 
 	const handleSignOut = async () => {
 		try {
+			setLoading(true);
 			await auth.signOut();
 			navigate('/');
 		} catch (error) {
 			console.error('Error signing out:', error);
 			window.alert('Error signing out. Please try again.');
 			// TODO ADD TOAST ONCE COMPONENT IS COMPLETE
+		} finally {
+			setLoading(false);
 		}
 	};
 
@@ -73,6 +83,7 @@ export const SignOutButton = () => {
 			onClick={handleSignOut}
 			aria-label="Sign Out"
 		>
+			{loading ? <Spinner /> : null}
 			Sign Out
 		</button>
 	);


### PR DESCRIPTION
## Description

I had originally built an `if statement` in `App.jsx`. It checked on the loading state which was being set in `useShoppingListData`. If the loading state was true, the app would render a spinner component to let the user know something was happening. This  was however dependent on data. When data was not already saved in the browser (as in during development) this caused a permanent loading state. The deployed app, or any new browser were constantly loading because there was no data to trigger the loading state to change.This was the first thing App.jsx did so it could not access the the Login/ Sign Up logic to fetch the data. 
 
* The `if statement` was removed from `App.jsx`
* Loading state management and a `<Spinner/>` we added to the SignInButton and SignOutButton logic in useAuth.jsx.

## Related Issue

closes #46 

## Acceptance Criteria

None

## Type of Changes

`bug fix`

## Updates

### Before
This is the deployed App

https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/108297341/17ff6a9b-7a5a-4a37-81a1-00d0e58484df

This is the dev environment in an new browser window
https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/108297341/8171c9c0-1c82-4af8-91fd-4f9dbabf87f9



### After

This is the dev environment in an new browser window
<img width="1680" alt="issue-20{BUG_FIX -after" src="https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/108297341/1f7ceeaf-99e3-487d-b475-a800a7f99c94">
r window

## Testing Steps / QA Criteria

1. Open a new browser window that you do not use for development
2. Copy and paste this into the input https://tcl-66-smart-shopping-list.web.app/) -- the loader should render
3. Navigate to the main branch, copy and paste the dev url (http://localhost:3000/) into the input -- the loader should render
4. Navigate to sc-issue-20[BUG-FIX] branch, copy the dev url (http://localhost:3000/) into the input -- the loader should NOT render