### PR TITLE
Nav Padding fix

### DIFF
--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -131,12 +131,12 @@ export default function NavigationBar({ data, setListPath, setLoading }) {
 							{/* The user's lists display when the user's uid matches the uid contained in the listPath of a shopping list.*/}
 							{openFormModal ? (
 								<Modal isOpen={openFormModal} onClose={closeModal}>
-									<div className="flex flex-col gap-4 p-4">
+									<div className="flex flex-col gap-4 p-2">
 										<AddList setListPath={setListPath} />
 									</div>
 								</Modal>
 							) : (
-								<div className={`flex-col ${sidebarWidth} `}>
+								<div className={`flex-col ${sidebarWidth}`}>
 									<div
 										className={`flex min-h-12 xsm:h-[30vh] sm:h-[35vh] pt-2 pb-4 ${sidebarWidth}`}
 									>
@@ -147,7 +147,7 @@ export default function NavigationBar({ data, setListPath, setLoading }) {
 													user?.uid,
 											) ? (
 												<ul
-													className={`${sidebarWidth} gap-6 text-sm text-left overflow-auto`}
+													className={`${sidebarWidth} gap-6 text-sm text-left px-2 overflow-auto`}
 												>
 													{' '}
 													{data.map((list) => (
@@ -205,7 +205,7 @@ export default function NavigationBar({ data, setListPath, setLoading }) {
 														) !== user?.uid,
 												) ? (
 													<ul
-														className={`${sidebarWidth} gap-6 text-sm font-family: Inter font-medium leading-4 text-left rounded-lg min-h-12 overflow-auto`}
+														className={`${sidebarWidth} gap-6 text-sm px-2 text-left rounded-lg min-h-12 overflow-auto`}
 													>
 														{' '}
 														{data.map((list) => (

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -205,7 +205,7 @@ export default function NavigationBar({ data, setListPath, setLoading }) {
 														) !== user?.uid,
 												) ? (
 													<ul
-														className={`${sidebarWidth} gap-6 text-sm px-2 text-left rounded-lg min-h-12 overflow-auto`}
+														className={`${sidebarWidth} gap-6 text-sm px-2 text-left rounded-lg min-h-12 overflow-y-auto`}
 													>
 														{' '}
 														{data.map((list) => (

--- a/src/components/NavigationBarSingleList.jsx
+++ b/src/components/NavigationBarSingleList.jsx
@@ -32,7 +32,7 @@ export function NavigationBarSingleList({
 
 	return (
 		<li
-			className={`flex-grow justify-between px-6 h-12 bg-list rounded-lg shadow-sm mt-4 hover:bg-[#ebf5ff] hover:bg-opacity-85 ${windowLocationListPath && localStorageListName === name ? 'bg-[#ebf5ff] bg-opacity-85' : null}`}
+			className={`flex-grow justify-between xsm:px-4 sm:px-2 h-12 bg-list rounded-lg shadow-sm mt-4 hover:bg-[#ebf5ff] hover:bg-opacity-85 ${windowLocationListPath && localStorageListName === name ? 'bg-[#ebf5ff] bg-opacity-85' : null}`}
 		>
 			{/*The above hex code (#ebf5ff) only worked in the ternary operator in lowercase format, not uppercase.*/}
 			{/* Using Link instead of button */}


### PR DESCRIPTION
## Description

Updated padding/styling to keep the list components inside the nav bar.

## Type of Changes

enhancement

## Updates

### Before
<img width="207" alt="Screenshot 2024-04-05 at 12 12 24 AM" src="https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/98231995/c583ef5d-a7ba-43d1-a620-d6b828e76568">


### After
<img width="207" alt="Screenshot 2024-04-05 at 12 12 38 AM" src="https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/98231995/34d33c2e-8d7c-403e-bfe4-82aa1d4363d8">


## Testing Steps / QA Criteria

1. git pull from main
2. git checkout an-nav-padding
3. see that lists in the nav bar are confined to the nav bar instead of leaking out and covering the right border line of the nav