### PR TITLE
add x margin to nav bar list elements

### DIFF
--- a/src/components/NavigationBarSingleList.jsx
+++ b/src/components/NavigationBarSingleList.jsx
@@ -32,7 +32,7 @@ export function NavigationBarSingleList({
 
 	return (
 		<li
-			className={`flex-grow justify-between xsm:px-4 sm:px-2 h-12 bg-list rounded-lg shadow-sm mt-4 hover:bg-[#ebf5ff] hover:bg-opacity-85 ${windowLocationListPath && localStorageListName === name ? 'bg-[#ebf5ff] bg-opacity-85' : null}`}
+			className={`flex-grow justify-between xsm:px-4 sm:px-2 h-12 bg-list rounded-lg shadow-sm mt-4 hover:bg-[#ebf5ff] hover:bg-opacity-85 mx-1 ${windowLocationListPath && localStorageListName === name ? 'bg-[#ebf5ff] bg-opacity-85' : null}`}
 		>
 			{/*The above hex code (#ebf5ff) only worked in the ternary operator in lowercase format, not uppercase.*/}
 			{/* Using Link instead of button */}


### PR DESCRIPTION
Bug fix to nav bar elements margins.

Before (see "shared with me" section in nav bar):
<img width="776" alt="Screen Shot 2024-04-07 at 10 14 08 AM" src="https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/105468537/875bd580-5f90-414a-85ea-6ccc99585c4c">

After: 
![Screen Shot 2024-04-07 at 10 16 06 AM](https://github.com/the-collab-lab/tcl-66-smart-shopping-list/assets/105468537/8b56d27d-8958-4333-9126-fd6196b4b6f6)
